### PR TITLE
fixed required check

### DIFF
--- a/src/EnvProvider.php
+++ b/src/EnvProvider.php
@@ -73,12 +73,12 @@ class EnvProvider implements ServiceProviderInterface
 
             if (isset($options[self::CONFIG_KEY_REQUIRED])) {
                 if ($options[self::CONFIG_KEY_REQUIRED]) {
-                    \Dotenv::required($varName);
+                    \Dotenv::required($app['env.options']['prefix'] . '_'.strtoupper($varName));
                 }
             }
 
             if (isset($options[self::CONFIG_KEY_ALLOWED])) {
-                \Dotenv::required($varName, $options[self::CONFIG_KEY_ALLOWED]);
+                \Dotenv::required($app['env.options']['prefix'] . '_'.strtoupper($varName), $options[self::CONFIG_KEY_ALLOWED]);
             }
 
             if (isset($options[self::CONFIG_KEY_CAST])) {


### PR DESCRIPTION
as the prefix is already stripped away, the required check doesnt work as expected (in combination with type casting:

``` php
    'var_config' => [
        'debug' => [EnvProvider::CONFIG_KEY_CAST => EnvProvider::CAST_TYPE_BOOLEAN],
        'redis_port' => [EnvProvider::CONFIG_KEY_CAST => EnvProvider::CAST_TYPE_INT, EnvProvider::CONFIG_KEY_REQUIRED => true],
        'redis_host' => [EnvProvider::CONFIG_KEY_REQUIRED => true]
    ]
```

with this `env` file:

```
SILEX_ENV=dev
SILEX_DEBUG=false
SILEX_REDIS_HOST=127.0.0.1
SILEX_REDIS_PORT=6379
```

the type casting is done on the $app variables, but the required check uses the `raw` env vars...
